### PR TITLE
Port darkfix to Anki 2.1

### DIFF
--- a/darkfix.py
+++ b/darkfix.py
@@ -18,8 +18,8 @@
 # - Fixed invalid colour values in range lightness_list.
 
 from anki.hooks import wrap
-from aqt import editor, browser, reviewer
-from aqt.qt import QPalette, QColor
+from aqt import mw, editor, browser, reviewer, webview
+from aqt.qt import Qt, QPalette, QColor
 import collections
 import math
 import re
@@ -54,6 +54,10 @@ def main():
     browser.COLOUR_SUSPENDED = coloursuspended.name()
     browser.COLOUR_MARKED = colourmarked.name()
     browser.flagColours = flagcolours
+
+    # Fix main window backgrounds.
+    for w in (mw.toolbarWeb, mw.web, mw.bottomWeb):
+        w.page().setBackgroundColor(Qt.white)
 
     # Inject colouring into the web view.
     editor._html = ("<style>.fname { color: %s; }</style>" % textcolour.name()) + editor._html

--- a/darkfix.py
+++ b/darkfix.py
@@ -29,13 +29,6 @@ def main():
     textcolour = p.color(QPalette.Text)
     basecolour = p.color(QPalette.Base)
 
-    # Inject background colour into the browser.
-    def tree_colour_hook(self):
-        p = self.form.tree.palette()
-        p.setColor(QPalette.Base, basecolour)
-        self.form.tree.setPalette(p)
-    browser.Browser.setupTree = wrap(browser.Browser.setupTree, tree_colour_hook)
-
     # Change suspend and mark colours.
     coloursuspended = QColor()
     coloursuspended.setNamedColor(browser.COLOUR_SUSPENDED)
@@ -58,15 +51,7 @@ def main():
     browser.COLOUR_MARKED = colourmarked.name()
 
     # Inject colouring into the web view.
-    editor._html = re.sub(
-        "(\\.fname\s*\\{)",
-        "\\1 color: {0};".format(textcolour.name()),
-        editor._html)
-    # Fix the default text colour for type answer edit elements.
-    reviewer.Reviewer._css = re.sub(
-        "(#typeans\s*\\{)",
-        "\\1 color: {0};".format(textcolour.name()),
-        reviewer.Reviewer._css)
+    editor._html = ("<style>.fname { color: %s; }</style>" % textcolour.name()) + editor._html
 
 def get_new_lightness(existing, pref):
     """Given a list of existing lightness return a new, different value.

--- a/darkfix.py
+++ b/darkfix.py
@@ -41,7 +41,14 @@ def main():
     lightness_blacklist = [textcolour.lightness()]
     hue_blacklist = [basecolour.hue(), textcolour.hue()]
     lightness_preference = max(basecolour.lightness(), 40)
-    for colour in [coloursuspended, colourmarked, *flagcolours.values()]:
+
+    for colour in flagcolours.values():
+        (h, s, l, a) = colour.getHsl()
+        new_lightness = get_new_lightness(lightness_blacklist, lightness_preference)
+        hue_blacklist.append(h)
+        colour.setHsl(h, s, new_lightness, a)
+
+    for colour in [coloursuspended, colourmarked]:
         (h, s, l, a) = colour.getHsl()
         new_lightness = get_new_lightness(lightness_blacklist, lightness_preference)
         # print("Considering {0} with preference {2} choose lightness {1}\n".format(
@@ -51,6 +58,7 @@ def main():
         #     hue_blacklist, new_hue, h))
         hue_blacklist.append(new_hue)
         colour.setHsl(new_hue, s, new_lightness, a)
+
     browser.COLOUR_SUSPENDED = coloursuspended.name()
     browser.COLOUR_MARKED = colourmarked.name()
     browser.flagColours = flagcolours

--- a/darkfix.py
+++ b/darkfix.py
@@ -61,7 +61,7 @@ def main():
 
     browser.COLOUR_SUSPENDED = coloursuspended.name()
     browser.COLOUR_MARKED = colourmarked.name()
-    browser.flagColours = flagcolours
+    browser.flagColours = {k: v.name() for k, v in flagcolours.items()}
 
     # Fix main window backgrounds.
     for w in (mw.toolbarWeb, mw.web, mw.bottomWeb):

--- a/darkfix.py
+++ b/darkfix.py
@@ -20,6 +20,7 @@
 from anki.hooks import wrap
 from aqt import mw, editor, browser, reviewer, webview
 from aqt.qt import Qt, QPalette, QColor
+from aqt.webview import AnkiWebView
 import collections
 import math
 import re
@@ -65,7 +66,9 @@ def main():
 
     # Fix main window backgrounds.
     for w in (mw.toolbarWeb, mw.web, mw.bottomWeb):
-        w.page().setBackgroundColor(Qt.white)
+        w._getWindowColor = lambda: QColor(Qt.white)
+
+    AnkiWebView._getWindowColor = lambda self: self.palette().color(QPalette.Window)
 
     # Inject colouring into the web view.
     editor._html = ("<style>.fname { color: %s; }</style>" % textcolour.name()) + editor._html

--- a/darkfix.py
+++ b/darkfix.py
@@ -37,10 +37,11 @@ def main():
     coloursuspended.setNamedColor(browser.COLOUR_SUSPENDED)
     colourmarked = QColor()
     colourmarked.setNamedColor(browser.COLOUR_MARKED)
+    flagcolours = {k: QColor(v) for k, v in browser.flagColours.items()}
     lightness_blacklist = [textcolour.lightness()]
     hue_blacklist = [basecolour.hue(), textcolour.hue()]
     lightness_preference = max(basecolour.lightness(), 40)
-    for colour in [coloursuspended, colourmarked]:
+    for colour in [coloursuspended, colourmarked, *flagcolours.values()]:
         (h, s, l, a) = colour.getHsl()
         new_lightness = get_new_lightness(lightness_blacklist, lightness_preference)
         # print("Considering {0} with preference {2} choose lightness {1}\n".format(
@@ -52,6 +53,7 @@ def main():
         colour.setHsl(new_hue, s, new_lightness, a)
     browser.COLOUR_SUSPENDED = coloursuspended.name()
     browser.COLOUR_MARKED = colourmarked.name()
+    browser.flagColours = flagcolours
 
     # Inject colouring into the web view.
     editor._html = ("<style>.fname { color: %s; }</style>" % textcolour.name()) + editor._html

--- a/darkfix.py
+++ b/darkfix.py
@@ -83,7 +83,7 @@ def get_new_lightness(existing, pref):
                 else:            distance = abs(pref - val)
                 r = rating(space, distance, 256, crit_range=50, crit_value=0.85)
                 candidates.append((val, r))
-        candidates.sort(key=lambda (val, diff): diff)
+        candidates.sort(key=lambda c: c[1])
         return candidates[-1][0]
 
 
@@ -122,7 +122,7 @@ def get_new_hue(existing, pref):
         for i in range(len(existing)):
             a, b = existing[i], existing[(i + 1) % len(existing)]
             candidates.append(choose_best_between(a, b))
-        candidates.sort(key=lambda (val, diff): diff)
+        candidates.sort(key=lambda c: c[1])
         return candidates[-1][0]
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
These changes are backwards incompatible. Icons aren't handled yet.
![image](https://web.archive.org/web/20180821121033im_/https://i.pomf.fun/s0ie2l.png) → ![image](https://web.archive.org/web/20180821121020im_/https://i.pomf.fun/jpkwjd.png)
![image](https://web.archive.org/web/20180821121013im_/https://i.pomf.fun/woq0mm.png) → ![image](https://web.archive.org/web/20180821121003im_/https://i.pomf.fun/acrrc.png)
![image](https://web.archive.org/web/20180821121039im_/https://i.pomf.fun/f6gny6.png) ![image](https://web.archive.org/web/20180821121047im_/https://i.pomf.fun/3keq.png)